### PR TITLE
Changed brew install link

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -324,7 +324,7 @@ end
 
 def install_brew
   if RUBY_PLATFORM.downcase.include?("darwin")
-    run %{ ruby -e "$(curl -fsSL https://raw.github.com/mxcl/homebrew/go)" }
+    run %{ ruby -e "$(curl -fsSL https://raw.github.com/Homebrew/homebrew/go/install)" }
   end
 end
 


### PR DESCRIPTION
The URL component now includes /install at the end as per instructions on http://brew.sh/.  Running without /install at the end results in HTTP error code 400.
